### PR TITLE
bodyParser is initialized twice

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -28,8 +28,8 @@ app.use(
 );
 
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded());
 app.use(bodyParser.urlencoded({ extended: true }));
+
 app.set('view engine', 'ejs');
 app.set('views', [
   path.join(__dirname, 'views'),


### PR DESCRIPTION
First initialization gives following deprecated warning in console:
```
body-parser deprecated undefined extended: provide extended option app/server.ts:37:31
```