### PR TITLE
add routes for 404 and 500 errors

### DIFF
--- a/app/routes/api-routes.ts
+++ b/app/routes/api-routes.ts
@@ -12,8 +12,11 @@ router.get('/aggregated', async (req, res) => {
   res.send(aggregated);
 });
 
-router.get('/', (req, res) => {
-  return res.render('pages/map');
+router.get('*', function(req, res) {
+  res.status(404).json({
+    status: 404,
+    message: 'Page Not Found'
+  });
 });
 
 export default router;

--- a/app/server.ts
+++ b/app/server.ts
@@ -64,7 +64,15 @@ app.use(
     next: express.NextFunction
   ) => {
     console.error(err);
-    res.status(500).json({ error: 'Internal server error' });
+    res.status(500).render('pages/500');
+    next();
+  }
+);
+
+// Handling 404
+app.use(
+  (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    res.status(404).render('pages/404');
     next();
   }
 );

--- a/app/views/pages/404.ejs
+++ b/app/views/pages/404.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="no">
+  <%- include('partials/head') -%>
+  <body>
+    <%- include('partials/disclaimer') -%>
+
+    <div id="page-wrapper">
+      <section id="main" class="wrapper style2">
+        <div class="inner privacy-policy">
+          <header class="major special">
+            <h1>Finner ikke siden</h1>
+          </header>
+          <h3>Vi kan ikke finne siden eller tjenesten du etterspør.</h3>
+          <p>
+            Koblingen du klikket kan være ødelagt, eller siden kan ha blitt
+            fjernet.
+          </p>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/app/views/pages/500.ejs
+++ b/app/views/pages/500.ejs
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="no">
+<%- include('partials/head') -%>
+<body>
+    <%- include('partials/disclaimer') -%>
+    <div id="page-wrapper">
+        <section id="main" class="wrapper style2">
+            <div class="inner privacy-policy">
+                <header class="major special">
+                    <h1>Noe Gikk Galt!</h1>
+                </header>
+                <h3>Her har det skjedd noe galt. </h3>
+                <p>
+                    <p>Send en mail til
+                        <a href="mailto:kontakt@bustbyte.no">kontakt@bustbyte.no</a>
+                        hvis du ikke finner løsningen på problemet.</p>
+                </p>
+            </div>
+        </section>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
I have made a couple of fallback routes for handling pages not found (404) and internal server error (500).
There is also a route for 404 in api-routes.