### PR TITLE
Update Facebook botton to not use any Facebook SDK

### DIFF
--- a/app/views/partials/share.ejs
+++ b/app/views/partials/share.ejs
@@ -3,6 +3,6 @@
     class="facebook-button"
     target="_blank"
     href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fcoronastatus.no%2F&amp;src=sdkpreparse"
-    >Share on Facebook <strong>1,4k</strong></a
+    ><%= __('Share on') %> Facebook <strong>1,4k</strong></a
   >
 </div>

--- a/app/views/partials/share.ejs
+++ b/app/views/partials/share.ejs
@@ -1,5 +1,8 @@
-<div class="share-buttons">
-  <div id="fb-root"></div>
-  <script async defer crossorigin="anonymous" src="https://connect.facebook.net/nn_NO/sdk.js#xfbml=1&version=v6.0&appId=3109699215720408&autoLogAppEvents=1"></script>
-  <div class="fb-share-button" data-href="https://coronastatus.no" data-layout="button_count" data-size="large"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fcoronastatus.no%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">Del</a></div>
+<div class="share-buttons" style="margin-top: 1rem;">
+  <a
+    class="facebook-button"
+    target="_blank"
+    href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fcoronastatus.no%2F&amp;src=sdkpreparse"
+    >Share on Facebook <strong>1,4k</strong></a
+  >
 </div>

--- a/static/main.css
+++ b/static/main.css
@@ -3834,3 +3834,15 @@ body.is-preload #banner .inner {
 .alert-dark .alert-link {
   color: #040505;
 }
+
+.facebook-button {
+  background-color: #1877f2;
+  padding: 0.3rem 1rem;
+  color: white;
+  text-decoration: none;
+  border-radius: 3px;
+}
+.facebook-button strong {
+  margin-left: 5px;
+  color: white;
+}


### PR DESCRIPTION
Just to remove the privacy unfriendly Facebook SDK with a simple button:

<kbd><img width="383px" alt="Screenshot" src="https://user-images.githubusercontent.com/1079135/77235601-aafb3b00-6bb7-11ea-9773-706f2bccbf33.jpg"></kbd>

The number is just static for now. Not sure if number separators have a comma in Norwegian. It should be in Dutch.