### PR TITLE
Switch to Stadia Maps.

### DIFF
--- a/app/views/pages/map.ejs
+++ b/app/views/pages/map.ejs
@@ -124,10 +124,9 @@
         </div>
         <script src="https://d3js.org/d3.v4.js"></script>
         <script>
-            mapboxgl.accessToken = 'pk.eyJ1IjoiZnJlZHJpa3BlIiwiYSI6ImNrN3QxOGV4bTBuNmwzbG1yNnUzMXIyaWMifQ._pfjKIPQuSFRxSCv8oRLEA';
             var map = new mapboxgl.Map({
                 container: 'map',
-                style: 'mapbox://styles/mapbox/dark-v10',
+                style: 'https://tiles.stadiamaps.com/styles/alidade_smooth_dark.json',
                 center: [10.7522, 63.9139],
                 zoom: 4,
                 hash: true


### PR DESCRIPTION
Switches map integration to use Stadia Maps.

I'll need to know what TLDs we want to allow so we can whitelist those in our system.