### PR TITLE
changed en translation of privacy agreement checkbox text

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -101,7 +101,7 @@
   "How will my data be used?": "How will my data be used?",
   "Your health information is stored anonymously, and can not be used to identify you.": "Your health information is stored anonymously, and can not be used to identify you.",
   "Our privacy policy can be found here": "Our privacy policy can be found here",
-  "I agree to my being data in accordance with the privacy statement": "I agree to my being data in accordance with the privacy statement",
+  "I agree to my data being stored in accordance with the privacy statement": "I agree to my data being stored in accordance with the privacy statement",
   "Submit report": "Submit report",
   "Statistics": "Statistics",
   "Download the dataset as CSV": "Download the dataset as CSV",

--- a/app/locales/nl.json
+++ b/app/locales/nl.json
@@ -101,7 +101,7 @@
   "How will my data be used?": "Hoe worden mijn gegevens gebruikt?",
   "Your health information is stored anonymously, and can not be used to identify you.": "Uw gezondheidsinformatie wordt anoniem opgeslagen en kan niet aan u worden gekoppeld.",
   "Our privacy policy can be found here": "Onze privacyverklaring vind je hier",
-  "I agree to my being data in accordance with the privacy statement": "Ik ga ermee akkoord dat mijn gegevens worden opgeslagen in overeenstemming met de privacyverklaring",
+  "I agree to my data being stored in accordance with the privacy statement": "Ik ga ermee akkoord dat mijn gegevens worden opgeslagen in overeenstemming met de privacyverklaring",
   "Submit report": "Rapport indienen",
   "In total": "In totaal hebben",
   "people have reported that they experience symptoms.": "mensen gemeld dat ze positief zijn getest op COVID-19 en symptomen hebben.",

--- a/app/locales/no.json
+++ b/app/locales/no.json
@@ -101,7 +101,7 @@
   "How will my data be used?": "Hvordan blir dataene mine brukt?",
   "Your health information is stored anonymously, and can not be used to identify you.": "Dine helseopplysninger blir lagret anonymisert, og kan ikke kobles til deg.",
   "Our privacy policy can be found here": "Vår personvernerklæring finner du her",
-  "I agree to my being data in accordance with the privacy statement": "Jeg godtar at mine data lagres i henhold til personvernerklæringen",
+  "I agree to my data being stored in accordance with the privacy statement": "Jeg godtar at mine data lagres i henhold til personvernerklæringen",
   "Submit report": "Send inn rapportering",
   "Statistics": "Statistikk",
   "Download the dataset as CSV": "Last ned datasett som CSV",

--- a/app/views/pages/report.ejs
+++ b/app/views/pages/report.ejs
@@ -284,7 +284,7 @@
           <div class="row">
             <div class="col-12 input-block">
               <input required type="checkbox" id="accept-privacy-policy" name="accept-privacy-policy" <%= passcode ? 'checked' : '' %>>
-              <label for="accept-privacy-policy" class="normal-font"><%= __('I agree to my being data in accordance with the privacy statement')%></label>
+              <label for="accept-privacy-policy" class="normal-font"><%= __('I agree to my data being stored in accordance with the privacy statement')%></label>
             </div>
           </div>
           <div class="row">


### PR DESCRIPTION
The previous translation doesn't really mean anything in english. 
"I agree to my being data in accordance with the privacy statement" to me means "I am data and I am in accordance with the privacy statement"

I am suggesting changing it to this. "I agree to my data being stored in accordance with the privacy statement" 