### PR TITLE
Make map center configurable

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -11,7 +11,13 @@ import statisticsRoutes from './routes/statistics-routes';
 import variousRoutes from './routes/various-routes';
 import { getInstance } from './repository/SqlLiteDatabase';
 import { swaggerDocument } from './swagger';
-import { LANGUAGE, BASE_URL, COUNTRY, MAP_CENTER, MAP_ZOOM } from '../config.json';
+import {
+  LANGUAGE,
+  BASE_URL,
+  COUNTRY,
+  MAP_CENTER,
+  MAP_ZOOM
+} from '../config.json';
 import { urls } from './domain/urls';
 
 const app = express();

--- a/app/server.ts
+++ b/app/server.ts
@@ -11,7 +11,7 @@ import statisticsRoutes from './routes/statistics-routes';
 import variousRoutes from './routes/various-routes';
 import { getInstance } from './repository/SqlLiteDatabase';
 import { swaggerDocument } from './swagger';
-import { LANGUAGE, BASE_URL, COUNTRY } from '../config.json';
+import { LANGUAGE, BASE_URL, COUNTRY, MAP_CENTER, MAP_ZOOM } from '../config.json';
 import { urls } from './domain/urls';
 
 const app = express();
@@ -63,6 +63,8 @@ app.use((req, res, next) => {
   res.locals.htmlLang = LANGUAGE;
   res.locals.country = COUNTRY;
   res.locals.baseUrl = BASE_URL;
+  res.locals.mapCenter = MAP_CENTER;
+  res.locals.mapZoom = MAP_ZOOM;
   res.locals.urls = urls;
   next();
 });

--- a/app/views/pages/map.ejs
+++ b/app/views/pages/map.ejs
@@ -127,8 +127,8 @@
             var map = new mapboxgl.Map({
                 container: 'map',
                 style: 'https://tiles.stadiamaps.com/styles/alidade_smooth_dark.json',
-                center: [10.7522, 63.9139],
-                zoom: 4,
+                center: [<%= locals.mapCenter %>],
+                zoom: <%= locals.mapZoom %>,
                 hash: true
             });
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,7 @@
 {
   "BASE_URL": "coronastatus.no",
   "LANGUAGE": "no",
-  "COUNTRY":"Norway"
+  "COUNTRY":"Norway",
+  "MAP_CENTER": "10.7522, 63.9139",
+  "MAP_ZOOM": 4
 }


### PR DESCRIPTION
This makes the map center and zoom level configurable from the config file, so it's site-specific.

The Norway values are in the example, these are the ones for the Netherlands (@adriaanvanrossum):

  "MAP_CENTER": "5.2793, 52.2129",
  "MAP_ZOOM": 7

@sbocinec You can add the SK ones in the config for your instance

