### PR TITLE
Fix translations and links in privacy policy

### DIFF
--- a/app/views/pages/en-lang-privacy-policy.ejs
+++ b/app/views/pages/en-lang-privacy-policy.ejs
@@ -1,68 +1,72 @@
-<!DOCTYPE html>
-<html lang="<%= locals.htmlLang %>">
+<!-- prettier spacer -->
 
-<head>
-    <%- include('partials/head') -%>
-</head>
+<%- include('partials/header') -%>
 
-<body>
-<%- include('partials/disclaimer') -%>
-<%- include('partials/menu') -%>
-<%- include('partials/hamburger-menu') -%>
-<div id="page-wrapper">
-    <section id="main" class="wrapper">
-        <div class="inner privacy-policy">
-            <h1><%= __("Privacy Policy") %></h1>
-            <p class="subtitle">What data do we store about you and why?</p>
-            <h3>Gender</h3>
-            <p>We store gender to be able to say something about the distribution between men and women with
-                symptoms.</p>
-            <h3>Age goup</h3>
-            <p>We store age groups to distinguish which age groups experience symptoms.</p>
-            <h3>Postcode</h3>
-            <p>
-                To give the public insight into how many people show symptoms in the area where they live, we store
-                postcodes.
-                In this way we can show overview of the number of people with specific symptoms in different areas.
-            </p>
-            <h3>Test status</h3>
-            <p>
-                We also save whether you have been tested and what the results of this test are. With this information
-                we can calculate the percentage of the participants who show symptoms. We display this on a map.
-            </p>
-            <h3>Symptoms</h3>
-            <p>
-                The symptoms you submit indicate whether you may be infected with the Covid-19 virus. The timing of the
-                onset of symptoms also gives an indication of how long you've been contagious. We collect this data and
-                visualize it anonymously. In this way, the public can gain insight into how big the figures can be.
-            </p>
-            <h2>Cookies</h2>
-            <p>
-                We use cookies to store participant data in their own browser. We first ask permission for this. With
-                these cookies, participants can anonymously report if their symptoms have decreased.
-            </p>
-            <h2>Delete data</h2>
-            <p>All stored data is anonymized and we do not store any personal data that can be deleted.</p>
-            <h2>Share data with National Health Service</h2>
-            <p>If desired, we provide anonymous data to the NHS.</p>
-            <h2>Analytics</h2>
-            <p>
-                We use analytics to gain insight into the use of the website. We use <a
-                        href="https://simpleanaltyics.io" target="_blank">Simple Analytics</a> for this - a party that
-                does not store personal data and does not place cookies.</p>
-            <h2>More questions?</h2>
-            <p>Contact us on Twitter: <a href="https://twitter.com/coronastatusNL"
-                                         target="_blank">@coronastatusNL</a>.</p>
-        </div>
-    </section>
-</div>
-<script>
-  // Remove query params from url
-  if (window.history.replaceState) {
-    window.history.replaceState({}, document.title, window.location.pathname);
-  }
-</script>
-<script src="/static/hamburger-menu.js?v=<%= locals.cacheKey %>"></script>
-</body>
+<h1><%= __("Privacy Policy") %></h1>
+<p class="subtitle">What data do we store about you and why?</p>
 
-</html>
+<h3>Gender</h3>
+<p>
+  We store gender to be able to say something about the distribution between men
+  and women with symptoms.
+</p>
+
+<h3>Age goup</h3>
+<p>
+  We store age groups to distinguish which age groups experience symptoms.
+</p>
+
+<h3>Postcode</h3>
+<p>
+  To give the public insight into how many people show symptoms in the area
+  where they live, we store postcodes. In this way we can show overview of the
+  number of people with specific symptoms in different areas.
+</p>
+
+<h3>Test status</h3>
+<p>
+  We also save whether you have been tested and what the results of this test
+  are. With this information we can calculate the percentage of the participants
+  who show symptoms. We display this on a map.
+</p>
+
+<h3>Symptoms</h3>
+<p>
+  The symptoms you submit indicate whether you may be infected with the Covid-19
+  virus. The timing of the onset of symptoms also gives an indication of how
+  long you've been contagious. We collect this data and visualize it
+  anonymously. In this way, the public can gain insight into how big the figures
+  can be.
+</p>
+
+<h2>Cookies</h2>
+<p>
+  We use cookies to store participant data in their own browser. We first ask
+  permission for this. With these cookies, participants can anonymously report
+  if their symptoms have decreased.
+</p>
+
+<h2>Delete data</h2>
+<p>
+  All stored data is anonymized and we do not store any personal data that can
+  be deleted.
+</p>
+
+<h2>Share data with National Health Service</h2>
+<p>If desired, we provide anonymous data to the NHS.</p>
+
+<h2>Analytics</h2>
+<p>
+  We use analytics to gain insight into the use of the website. We use
+  <a href="https://simpleanalytics.com" target="_blank">Simple Analytics</a>
+  for this - a party that does not store personal data and does not place
+  cookies.
+</p>
+
+<h2>More questions?</h2>
+<p>
+  Contact us on Twitter:
+  <a href="https://twitter.com/coronastatusNL" target="_blank"
+    >@coronastatusNL</a
+  >.
+</p>

--- a/app/views/pages/nl-lang-privacy-policy.ejs
+++ b/app/views/pages/nl-lang-privacy-policy.ejs
@@ -3,29 +3,34 @@
 <%- include('partials/header') -%>
 
 <h1><%= __("Privacy Policy") %></h1>
-<p class="subtitle">Welke gegevens slaan we over u op en waarom?</p>
+<p>Welke gegevens slaan we over u op en waarom?</p>
+
 <h3>Geslacht</h3>
 <p>
   We slaan geslacht op om iets te kunnen zeggen over de verdeling tussen mannen
   en vrouwen met klachten.
 </p>
+
 <h3>Leeftijdsgroep</h3>
 <p>
   We slaan leeftijdsgroepen op om te onderscheiden welke leeftijdsgroepen
   symptomen ervaren.
 </p>
+
 <h3>Postcode</h3>
 <p>
   Om het publiek inzicht te geven in hoeveel mensen symptomen vertonen in het
   gebied waar ze wonen, slaan we postcodes op. Op deze manier kunnen we een
   overzicht tonen van het aantal dat symptomen heeft op verschillende gebieden.
 </p>
+
 <h3>Test status</h3>
 <p>
   We slaan ook op of u bent getest en wat de resultaten zijn van deze test. Met
   deze informatie kunnen wij een percentage berekenen van de deelnemers die
   symptomen vertonen. Dit geven wij weer op een kaart.
 </p>
+
 <h3>Symptomen</h3>
 <p>
   De symptomen die u indient, geven aan of u mogelijk besmet bent met het
@@ -34,29 +39,34 @@
   visualiseren deze anoniem. Op deze manier kan het publiek inzicht krijgen in
   hoe groot de cijfers kunnen zijn.
 </p>
+
 <h2>Cookies</h2>
 <p>
   We gebruiken cookies om gegevens van deelnemers op te slaan in hun eigen
   browser. Wij vragen hiervoor eerst toestemming. Met deze cookies kunnen
   deelnemers anoniem laten weten als hun klachten zijn afgenomen.
 </p>
+
 <h2>Gegevens verwijderen</h2>
 <p>
   Alle opgeslagen gegevens zijn geanonimiseerd en we slaan geen persoonlijke
   gegevens op die kunnen worden verwijderd.
 </p>
+
 <h2>Gegevens delen met RIVM</h2>
 <p>
   Desgewenst verstrekken wij anonieme gegevens aan het Rijksinstituut voor
   Volksgezondheid en Milieu.
 </p>
+
 <h2>Analytics</h2>
 <p>
   We gebruiken analytics om inzicht te krijgen in het gebruik van de website. We
   gebruiken daarvoor
-  <a href="https://simpleanaltyics.io" target="_blank">Simple Analytics</a>
+  <a href="https://simpleanalytics.com" target="_blank">Simple Analytics</a>
   - een partij die geen persoonsgegevens op slaat en geen cookies plaatst.
 </p>
+
 <h2>Vraag je je iets af?</h2>
 <p>
   Neem contact op via Twitter:

--- a/app/views/pages/no-lang-privacy-policy.ejs
+++ b/app/views/pages/no-lang-privacy-policy.ejs
@@ -1,29 +1,33 @@
 <%- include('partials/header') -%>
 
 <h1><%= __("Privacy Policy") %></h1>
-<p class="subtitle">Hvilken data lagrer vi om deg, og hvorfor?</p>
-<p></p>
+<p>Hvilken data lagrer vi om deg, og hvorfor?</p>
+
 <h3>Kjønn</h3>
 <p>
   Vi lagrer kjønn for å kunne si noe om fordelingen mellom menn og kvinner som
   opplever symptomer.
 </p>
+
 <h3>Aldersgruppe</h3>
 <p>
   Vi lagrer aldersgruppe for å kunne skille på hvilke aldersgrupper som opplever
   symptomer.
 </p>
+
 <h3>Postnummer</h3>
 <p>
   For å kunne gi offentligheten et innblikk i hvor mange som viser symptomer i
   området der de bor, lagrer vi postnummer. På denne måten kan vi vise en
   oversikt over antall som har symptomer i ulike områder.
 </p>
+
 <h3>Teststatus</h3>
 <p>
   For å bedre anslå andelen av de som utviser symptomer som blir testet, lagrer
   vi også om du har blitt testet og resultatet av denne testen.
 </p>
+
 <h3>Symptomer</h3>
 <p>
   Symptomene du sender inn gir en indikator på hvorvidt du kan være smittet av
@@ -32,19 +36,23 @@
   visualisere dem anonymt. På denne måten kan offentliggheten få et innblikk i
   hvor store mørketallene potensielt kan være.
 </p>
+
 <h2>Informasjonskapsler (Cookies)</h2>
 <p>
   For å nå ut til flest mulig har vi lagt til en knapp for å dele siden på
   Facebook. Dette medfører at informasjonskapsler fra Facebook blir satt i din
   nettleser.
 </p>
+
 <h2>Sletting av data</h2>
 <p>
   All data som blir lagret er anonymisert, og vi lagrer ingen persondata som kan
   slettes.
 </p>
+
 <h2>Deling av data med FHI</h2>
 <p>Vi vil overlevere data til Folkehelseinstituttet om de skulle ønske det.</p>
+
 <h2>Lurer du på noe?</h2>
 <p>
   Send en mail til <a href="mailto:kontakt@bustbyte.no">kontakt@bustbyte.no</a>.


### PR DESCRIPTION
Removed some code while merging master into https://github.com/BustByte/coronastatus/pull/263. Not this is fixed in this PR.