### PR TITLE
Add support for configurable ZIP code

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -17,7 +17,9 @@ import {
   COUNTRY,
   MAP_CENTER,
   MAP_ZOOM,
-  TWITTER
+  TWITTER,
+  ZIP_LENGTH,
+  ZIP_PLACEHOLDER
 } from '../config.json';
 import { urls } from './domain/urls';
 
@@ -74,6 +76,8 @@ app.use((req, res, next) => {
   res.locals.mapZoom = MAP_ZOOM;
   res.locals.twitter = TWITTER;
   res.locals.urls = urls;
+  res.locals.zipLength = ZIP_LENGTH;
+  res.locals.zipPlaceHolder = ZIP_PLACEHOLDER;
   next();
 });
 

--- a/app/views/pages/report.ejs
+++ b/app/views/pages/report.ejs
@@ -180,7 +180,7 @@
     </p>
 
     <h4 for="postal-code"><%= __('Zip code') %></h4>
-    <input class="appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required type="text" pattern="[0-9]{4}" maxlength="4" name="postal-code" id="postal-code" placeholder="1234" value="<%= postalCode %>">
+    <input class="appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" required type="text" pattern="[0-9]{<%= locals.zipLength %>}" maxlength="<%= locals.zipLength %>" name="postal-code" id="postal-code" placeholder="<%= locals.zipPlaceHolder %>" value="<%= postalCode %>">
 
     <div class="flex flex-row items-center mt-8">
       <img src="/static/images/mask.svg" alt="" class="h-16 w-16">

--- a/config.example.json
+++ b/config.example.json
@@ -4,5 +4,7 @@
   "COUNTRY": "Norway",
   "MAP_CENTER": "10.7522, 63.9139",
   "MAP_ZOOM": 4,
-  "TWITTER": "coronastatusNO"
+  "TWITTER": "coronastatusNO",
+  "ZIP_LENGTH": 4,
+  "ZIP_PLACEHOLDER": "1234"
 }


### PR DESCRIPTION
Current implementation uses a ZIP code with a fixed length (4). The zip length format and length differs between the countries (Slovakia: 5, US: 5, ...), the current implementation does not support those countries.

This PR brings support to configure the ZIP length in the `config.json`. It does not handle all possible cases (e.g. UK uses alphanumeric ZIP though...).

https://en.wikipedia.org/wiki/List_of_postal_codes