### PR TITLE
Add config option for db path/name

### DIFF
--- a/app/repository/CovidReportRepository.ts
+++ b/app/repository/CovidReportRepository.ts
@@ -3,6 +3,8 @@ import { getInstance, SqlLiteDatabase } from './SqlLiteDatabase';
 import { CovidReport } from '../domain/types';
 import { CacheWithLifetime } from './CacheWithLifetime';
 
+import { DB_PATH } from '../../config.json';
+
 const SELECT_ALL_COVID_REPORTS = 'select passcode, json_dump from covid_report';
 
 const SELECT_COVID_REPORT = 'select * from covid_report where passcode = (?)';
@@ -28,7 +30,7 @@ export class CovidReportRepository {
   db: SqlLiteDatabase;
 
   constructor() {
-    this.db = getInstance('covid_db');
+    this.db = getInstance(DB_PATH);
   }
 
   async addNewCovidReport(

--- a/app/server.ts
+++ b/app/server.ts
@@ -20,7 +20,8 @@ import {
   TWITTER,
   ZIP_LENGTH,
   ZIP_PLACEHOLDER,
-  REDIRECT_TO_GOVERNMENT
+  REDIRECT_TO_GOVERNMENT,
+  DB_PATH
 } from '../config.json';
 import { urls } from './domain/urls';
 
@@ -132,7 +133,7 @@ app.use(
 );
 
 async function initializeDatabase(): Promise<void> {
-  const db = getInstance('covid_db');
+  const db = getInstance(DB_PATH);
   const numberOfTables = (await db.listTables()).length;
   if (numberOfTables === 0) {
     await db.applyMigrationScripts(

--- a/config.example.json
+++ b/config.example.json
@@ -8,5 +8,6 @@
   "ZIP_LENGTH": 4,
   "ZIP_PLACEHOLDER": "1234",
   "REDIRECT_TO_GOVERNMENT": false,
-  "PASSCODE_LENGTH": 3
+  "PASSCODE_LENGTH": 3,
+  "DB_PATH": "./covid_db"
 }


### PR DESCRIPTION
Add the config option `DB_PATH` to allow choosing where the database file should be saved.

Having the config option instead of a hardcoded path made it simple for us to save the db on our persistent storage when running a container.