### PR TITLE
refactor: docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-buster-slim
+FROM node:lts-alpine
 
 RUN mkdir /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./:/app
       - node_modules:/app/node_modules
     ports:
-      - 7272:7272
+      - "127.0.0.1:7272:7272"
     networks:
       - cs
     restart: unless-stopped


### PR DESCRIPTION
The _alpine_ variant seems to be half of the size of _buster-slim_.
With Docker a regular port mapping opens the port to the world. I would suggest to open it only locally by specifying the local IP before the ports, [see the docs](https://docs.docker.com/compose/compose-file/#ports).