### PR TITLE
Show correct cookie setting in form after submit, Fix #261

### DIFF
--- a/app/routes/report-routes.ts
+++ b/app/routes/report-routes.ts
@@ -178,7 +178,11 @@ router.post('/', createReportRateLimit, async (req, res) => {
   const acceptRemember = req.body['accept-remember'] === 'on';
 
   // Set cookie with passcode
-  if (acceptRemember) res.cookie('passcode', passcode, cookieOptions);
+  if (acceptRemember) {
+    res.cookie('passcode', passcode, cookieOptions);
+  } else {
+    res.clearCookie('passcode');
+  }
 
   reportRepo.addNewCovidReport(passcode, covidReport);
   if (req.body['passcode']) {

--- a/app/views/pages/report.ejs
+++ b/app/views/pages/report.ejs
@@ -503,6 +503,9 @@
   }
 
   changeTestResultDisplay(document.getElementById("been-tested-yes").checked);
+
+  var hasPasscodeCookie = document.cookie.includes('passcode');
+  document.getElementById('accept-remember').checked = hasPasscodeCookie;
 </script>
 
 <script>


### PR DESCRIPTION
Also clears the existing cookie if the user unchecks the option and resubmits.