### PR TITLE
Added footer link for analytics

### DIFF
--- a/app/views/partials/footer.ejs
+++ b/app/views/partials/footer.ejs
@@ -26,7 +26,7 @@
       />
     </a>
     <div
-      class="flex flex-row justify-between flex-wrap items-center self-stretch my-8 text-base lg:text-xl text-center"
+      class="flex flex-row justify-between flex-wrap items-center self-stretch mt-8 text-base lg:text-xl text-center"
     >
       <% if (locals.twitter) { %>
       <a
@@ -54,6 +54,18 @@
         ><%= __('Privacy Policy')%></a
       >
     </div>
+
+
+    <div
+    class="flex items-center justify-center self-stretch mt-4 mb-8 text-sm lg:text-base text-center"
+  >
+  <img src="/static/images/analytics.svg" alt="Provided by Simple Analtics" class="mr-2" />
+    <a target="_blank" class="font-bold text-cvs-green-dark hover:text-cvs-red hover:underline" href="https://simpleanalytics.com/<%= baseUrl %>"
+    ><%= __('View Website Statistics')%></a
+  >
+</div>
+      
+
   </div>
 </footer>
 <% } %>

--- a/static/images/analytics.svg
+++ b/static/images/analytics.svg
@@ -1,0 +1,6 @@
+
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect y="11.5151" width="3.33333" height="8.48485" fill="#F56565"/>
+    <rect x="8" y="6.6665" width="3.33333" height="13.3333" fill="#F56565"/>
+    <rect x="16.6667" width="3.33333" height="20" fill="#F56565"/>
+</svg>


### PR DESCRIPTION
Added footer link for analytics.
The hyperlink picks up base URL to create link to: simpleanalytics.com/coronastatus.xx

![image](https://user-images.githubusercontent.com/25029371/77701454-43c1fa00-6fae-11ea-9ba4-3e603124c639.png)
