### PR TITLE
Revert "force SSL by redirecting from http to https (#362)"

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -17,7 +17,7 @@ import { ensureAllLocalesAreValidJSON } from './util/locale-validation';
 
 const app = express();
 const port = process.env.PORT || 7272;
-const isDevelopmentEnv = process.env.NODE_ENV !== 'production';
+const isDevelopmentEnv = process.env.NODE_ENV === 'dev';
 
 i18n.configure({
   locales: [config.LANGUAGE],
@@ -81,14 +81,6 @@ app.set('views', [
   path.join(__dirname, 'views'),
   path.join(__dirname, 'views', 'errors')
 ]);
-
-app.use((req, res, next) => {
-  if (req.header('x-forwarded-proto') !== 'https' && !isDevelopmentEnv) {
-    res.redirect(`https://${req.header('host')}${req.url}`);
-  } else {
-    next();
-  }
-});
 
 app.use(urls.submitReport, reportRoutes);
 app.use(urls.map, mapRoutes);


### PR DESCRIPTION
This reverts commit 539a66535c55410d413cd114e8a9c8774375acc6. Fixes #382 

I think all instances run behind a reverse proxy, https redirects should probably be handled there instead.