### PR TITLE
Add script for finding missing translations across all locales

### DIFF
--- a/ops/lost-in-translation.py
+++ b/ops/lost-in-translation.py
@@ -34,7 +34,6 @@ def retrieve_json_for_file_at_commit_hash(file_path, commit_hash):
 
 if __name__ == '__main__':
     all_locales = ('no', 'se', 'en-IN')
-    locale_to_check_for = 'no'
     
     # Step 1: Find all the (english) translation keys across all branches and PRs.
     #

--- a/ops/lost-in-translation.py
+++ b/ops/lost-in-translation.py
@@ -1,0 +1,80 @@
+from subprocess import call, check_output, STDOUT
+from json import loads as decode_json, JSONDecodeError
+
+'''
+   This script finds all the english translation keys across
+   all commits (including branches and pull requests) for each
+   locale.json in app/locales. Afterwards it looks at each locale
+   separately to see if it's missing any one the english keys.
+
+   Usage: python3 ops/lost-in-translation.py
+   Important: You need to run it from the root directory.
+'''
+
+def git(*args):
+    '''Calls git cli with arguments.'''
+    stdout = check_output(['git', *args], stderr=STDOUT)
+    return stdout
+
+def find_commit_hashes_for_file(file_path):
+    '''Returns the commit hashes for a file path across all local branches.'''
+    lines = git('log', '--pretty=format:"%h"', '--all', '--', file_path)
+    hashes = [line.replace('"', '') for line in lines.decode('utf-8').split('\n')]
+    return hashes
+
+def retrieve_json_for_file_at_commit_hash(file_path, commit_hash):
+   '''Returns the JSON representation of the contents of a file at certain commit hash.'''
+   contents_at_commit_hash = git('show', '%s:%s' % (commit_hash, file_path))
+   try:
+       json = decode_json(contents_at_commit_hash.decode('utf-8'))
+       return json
+   except JSONDecodeError:
+       # Sometimes the file is not in a proper JSON format. We simply return nothing in that case.
+       return {}
+
+if __name__ == '__main__':
+    all_locales = ('no', 'se', 'en-IN')
+    locale_to_check_for = 'no'
+    
+    # Step 1: Find all the (english) translation keys across all branches and PRs.
+    #
+    # If a Dutch developer has made a feature in a branch, we expect that him/her added a key
+    # to one or many locale files (usually the english locale (en.json) or to their own locale
+    # file (nl.json), or both).
+    #
+    # But they probably haven't added translations to all the other locales, because they don't
+    # speak the other languages. And this is the problem, because now we need find people to help
+    # translate the added keys to all the other locales.
+    #
+    # So what we do here is simply to find *all* the english translation keys across the entire
+    # project. That means looking at all the english translations keys in all the locale files
+    # since the start of the project across all branches and PRs. We throw them into a set that
+    # we use in the next step.
+    all_english_translation_keys = set([])
+    for locale in all_locales:
+        file_path = 'app/locales/%s.json' % locale
+        for commit_hash in find_commit_hashes_for_file(file_path):
+            translation = retrieve_json_for_file_at_commit_hash(file_path, commit_hash)
+            all_english_translation_keys.update(translation.keys())
+
+    # Step 2: For each locale file check if there are any missing english translation keys
+    #         across all branches and PRs and all commits/changes.
+    #
+    # If there's a missing english translation key, we know that we're most likely missing
+    # a translation for that locale. So what we need to do is to translate it, or get help
+    # to translate it.
+    # 
+    # We throw it into a dictionary where the key is the locale and the value is a set of 
+    # missing translations from english to that locale.
+    translation_keys_by_locale = {}
+    for locale in all_locales:
+        file_path = 'app/locales/%s.json' % locale
+        for commit_hash in find_commit_hashes_for_file(file_path):
+            translation = retrieve_json_for_file_at_commit_hash(file_path, commit_hash)
+            translation_keys_by_locale[locale] = translation_keys_by_locale.get(locale, set()).union(translation.keys())
+
+    # Step 3: Print out the missing keys for each locale.
+    for locale in all_locales:
+        for english_translation_key in all_english_translation_keys:
+            if not english_translation_key in translation_keys_by_locale[locale]:
+                print(locale, 'missing translation for:', english_translation_key)


### PR DESCRIPTION
The script is heavily commented with what I've been thinking. There might be a logical error here, so please read through the script to see if it makes sense.

This script will produce false positives (since it looks at all changes to the file ever). Why did I make it like that? Because translations are added at different points in time – a new feature branch will contain new translations, while all the existing branches and locales will be missing those. 

This will produce some false positives (translations which have been removed etc.), but it in turn include translations which are being worked on right now in different branches (which should allow us to start translating before the PR is done, and widen the bottleneck which is currently halting PRs). We could also just add the false positives to an ignore list to make them go away.

I'm hoping this should make it easier for us to quickly grab all missing translations for all locales and then handing them off to a non-technical person that don't know JSON or git, maybe via. a more friendly medium like Google Sheets. 

This is what I get if I run the script right now for `no`, `en-IN` and `se`. 

`no missing translation for: Sweden` basically means that the norwegian locale (`no.json`) has **never** had a row in its JSON file where the key is `Sweden` and the value is `Sverige`. 

Does this make sense? Haha, I'm actually not sure. Here's the full output:
```
no missing translation for: Sweden
no missing translation for: https://www.whatismyzip.com
no missing translation for: What is my Zip code?
---
se missing translation for: this
se missing translation for: https://who.org
se missing translation for:  article as an attempt to chart these numbers.
se missing translation for: In total <%= numberWithSpaces(totalPeopleInContactWithInfected) %> people have reported that they have been in close contact with a person who was tested positive for COVID-19.
se missing translation for: In total <%= numberWithSpaces(totalInfectedPeopleWithSymptoms) %> people have reported that they have tested positive for COVID-19 and experience symptoms.
se missing translation for: In total <%= numberWithSpaces(totalPeopleInContactWithInfected) %> people have reported that they have been tested for COVID-19.
se missing translation for: Join the most important crowdsource! Regardless if you're healthy or not, please submit the form below – that is also valuable information!
se missing translation for: Zip code information
se missing translation for: Netherlands
se missing translation for:  if you can't get it to work.
se missing translation for: I agree to my being data in accordance with the privacy statement
se missing translation for: To WHO.org
se missing translation for: /healthcondition/
se missing translation for: Using self-report, you can get a better picture of how many people have symptoms without exposing health workers to potential contamination hazards and without using up valuable infection control equipment that is already in short supply. We at Bustbyte, well helped by other volunteers, have created this tool in response to
se missing translation for: In total <%= numberWithSpaces(totalPeopleWithSymptoms) %> people have reported that they experience symptoms.
---
en-IN missing translation for: this
en-IN missing translation for: https://who.org
en-IN missing translation for:  article as an attempt to chart these numbers.
en-IN missing translation for: In total <%= numberWithSpaces(totalPeopleInContactWithInfected) %> people have reported that they have been in close contact with a person who was tested positive for COVID-19.
en-IN missing translation for: In total <%= numberWithSpaces(totalInfectedPeopleWithSymptoms) %> people have reported that they have tested positive for COVID-19 and experience symptoms.
en-IN missing translation for: In total <%= numberWithSpaces(totalPeopleInContactWithInfected) %> people have reported that they have been tested for COVID-19.
en-IN missing translation for: Join the most important crowdsource! Regardless if you're healthy or not, please submit the form below – that is also valuable information!
en-IN missing translation for: Zip code information
en-IN missing translation for: Netherlands
en-IN missing translation for:  if you can't get it to work.
en-IN missing translation for: I agree to my being data in accordance with the privacy statement
en-IN missing translation for: To WHO.org
en-IN missing translation for: /healthcondition/
en-IN missing translation for: Using self-report, you can get a better picture of how many people have symptoms without exposing health workers to potential contamination hazards and without using up valuable infection control equipment that is already in short supply. We at Bustbyte, well helped by other volunteers, have created this tool in response to
en-IN missing translation for: In total <%= numberWithSpaces(totalPeopleWithSymptoms) %> people have reported that they experience symptoms.
```