### PR TITLE
Fix typo on temperature units

### DIFF
--- a/app/locales/es-CL.json
+++ b/app/locales/es-CL.json
@@ -180,7 +180,7 @@
   "We can't find the page or service you're looking for": "No podemos encontrar la página o servicio que está buscando",
   "We stored your data in a cookie so come back later to update your status": "Guardamos tu informacion en una cookie para que puedas regresar a este sitio y actualizar tu estado de salud",
   "What is my Zip code?": "¿Cómo saber mi código postal?",
-  "What is your current body temperature? (Celcius)": "¿Cuál es tu temperatura corporal actual? (Celcius)",
+  "What is your current body temperature? (Celcius)": "¿Cuál es tu temperatura corporal actual? (Celsius)",
   "What was the result?": "¿Cuál fue el resultado?",
   "When did the symptoms start?": "¿Cuándo comenzaron los síntomas?",
   "Write it down somewhere or save it on your computer.": "Anótela en algún lugar o guardelo en su computador.",

--- a/app/locales/es-ES.json
+++ b/app/locales/es-ES.json
@@ -179,7 +179,7 @@
   "Waiting for result": "A la espera de resultado",
   "We can't find the page or service you're looking for": "No podemos encontrar la página o servicio que está buscando",
   "We stored your data in a cookie so come back later to update your status": "Guardamos su informacion en una cookie para que pueda regresar a este sitio y actualice su estado de salud",
-  "What is your current body temperature? (Celcius)": "¿Cuál es su temperatura corporal actual? (Celcius)",
+  "What is your current body temperature? (Celcius)": "¿Cuál es su temperatura corporal actual? (Celsius)",
   "What was the result?": "¿Cuál fue el resultado?",
   "When did the symptoms start?": "¿Cuándo comenzaron los síntomas?",
   "Write it down somewhere or save it on your computer.": "Anótela en algún lugar o guardelo en su computador.",


### PR DESCRIPTION
Replaces 'Celcius' with 'Celsius'